### PR TITLE
feat(testclass, mocksyntax): remove need for interfaces in mock class…

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: yarn
       - run: npm run build --if-present
       - run: npm test
       - run: npm run coverage

--- a/src/TestClass/MockMethodSyntax.ts
+++ b/src/TestClass/MockMethodSyntax.ts
@@ -1,26 +1,25 @@
 import TestClass from './TestClass';
 
 export default class MockMethodSyntax<
-  A extends Record<string, unknown>,
-  B extends Record<string, unknown>
+  ClassImpl extends ConstructorOf<ClassImpl['prototype']>
 > {
   public constructor(
-    private testClass: TestClass<A, B>,
+    private testClass: TestClass<ClassImpl>,
     private methodName: string | number | symbol
   ) {}
 
-  public withImplementation(implementation: jest.Mock): TestClass<A, B> {
+  public withImplementation(implementation: jest.Mock): TestClass<ClassImpl> {
     this.testClass.setMockImplementation(
-      this.methodName as keyof B,
+      this.methodName as keyof ClassImpl['prototype'],
       implementation
     );
 
     return this.testClass;
   }
 
-  public willReturn(returnValue: unknown): TestClass<A, B> {
+  public willReturn(returnValue: unknown): TestClass<ClassImpl> {
     this.testClass.setMockImplementation(
-      this.methodName as keyof B,
+      this.methodName as keyof ClassImpl['prototype'],
       jest.fn(() => returnValue)
     );
 
@@ -30,9 +29,9 @@ export default class MockMethodSyntax<
   /**
    * @description Returns a Promise which will resolve with the specified value
    */
-  public willReturnResolvedValue(returnValue: unknown): TestClass<A, B> {
+  public willReturnResolvedValue(returnValue: unknown): TestClass<ClassImpl> {
     this.testClass.setMockImplementation(
-      this.methodName as keyof B,
+      this.methodName as keyof ClassImpl['prototype'],
       jest.fn(() => Promise.resolve(returnValue))
     );
 
@@ -42,18 +41,18 @@ export default class MockMethodSyntax<
   /**
    * @description Returns a Promise which will reject with the specified value
    */
-  public willReturnRejectedValue(returnValue: unknown): TestClass<A, B> {
+  public willReturnRejectedValue(returnValue: unknown): TestClass<ClassImpl> {
     this.testClass.setMockImplementation(
-      this.methodName as keyof B,
+      this.methodName as keyof ClassImpl['prototype'],
       jest.fn(() => Promise.reject(returnValue))
     );
 
     return this.testClass;
   }
 
-  public willThrow(exception: Error): TestClass<A, B> {
+  public willThrow(exception: Error): TestClass<ClassImpl> {
     this.testClass.setMockImplementation(
-      this.methodName as keyof B,
+      this.methodName as keyof ClassImpl['prototype'],
       jest.fn(() => {
         throw exception;
       })

--- a/src/TestClass/index.test.ts
+++ b/src/TestClass/index.test.ts
@@ -22,17 +22,13 @@ class ClassToTest implements ClassToTestInterface {
 
 describe('assertion testing', () => {
   it('should create an instance', () => {
-    const testClass = TestClass.for<ClassToTest, ClassToTestInterface>(
-      ClassToTest
-    );
+    const testClass = TestClass.for(ClassToTest);
 
     expect(testClass).toBeInstanceOf(TestClass);
   });
 
   it('should return correct mock', () => {
-    const testClass = TestClass.for<ClassToTest, ClassToTestInterface>(
-      ClassToTest
-    ).getMock();
+    const testClass = TestClass.for(ClassToTest).getMock();
 
     expect(testClass.method1.toString()).toEqual(jest.fn().toString());
     expect(testClass.method2.toString()).toEqual(jest.fn().toString());
@@ -41,48 +37,41 @@ describe('assertion testing', () => {
 
   it('should return correct custom mock', () => {
     const method1 = jest.fn(() => 1);
-    const testClass = TestClass.for<ClassToTest, ClassToTestInterface>(
-      ClassToTest,
-      {
-        customMocks: {
-          method1: method1,
-        },
-      }
-    ).getMock();
+    const testClass = TestClass.for(ClassToTest, {
+      customMocks: {
+        method1: method1,
+      },
+    }).getMock();
 
     expect(testClass.method1).toEqual(method1);
   });
 
-  it('should return all mocks', () => {
-    const { instance, methodsToMockMap } = TestClass.testClassFor<
-      ClassToTest,
-      ClassToTestInterface
-    >(new ClassToTest());
-    expect(instance.method1).toBe(methodsToMockMap.method1);
-    expect(instance.method2).toBe(methodsToMockMap.method2);
-    expect(instance.method3).toBe(methodsToMockMap.method3);
+  it('should mock all methods of class', () => {
+    const testClass = TestClass.for(ClassToTest);
+
+    const instance = testClass.getMock();
+
+    expect(instance.method1).toBeTruthy();
+    expect(instance.method2).toBeTruthy();
+    expect(instance.method3).toBeTruthy();
   });
 
   it('should return custom mock', () => {
     const mock = jest.fn();
 
-    const { instance, methodsToMockMap } = TestClass.testClassFor<
-      ClassToTest,
-      ClassToTestInterface
-    >(new ClassToTest(), {
+    const testClass = TestClass.for(ClassToTest, {
       customMocks: {
         method1: mock,
       },
     });
 
+    const instance = testClass.getMock();
+
     expect(instance.method1).toBe(mock);
-    expect(methodsToMockMap.method1).toBe(mock);
   });
 
   it('Mock syntax returns correct return value', () => {
-    const mockedInstance = TestClass.for<ClassToTest, ClassToTestInterface>(
-      ClassToTest
-    )
+    const mockedInstance = TestClass.for(ClassToTest)
       .mockMethod('method1')
       .willReturn('test')
       .getMock();
@@ -92,9 +81,7 @@ describe('assertion testing', () => {
   });
 
   it('Mock syntax returns correct return value', () => {
-    const mockedInstance = TestClass.for<ClassToTest, ClassToTestInterface>(
-      ClassToTest
-    )
+    const mockedInstance = TestClass.for(ClassToTest)
       .mockMethod('method1')
       .willThrow(new Error())
       .getMock();

--- a/src/Type/Constructor.ts
+++ b/src/Type/Constructor.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/ban-types
+type ConstructorOf<T> = { new (...args: any[]): T } & Function;


### PR DESCRIPTION
… construction

Remove need for interfaces in Mock class construction by introducing ConstructorOf<T> type and
accessing prototype. Now users can simply use the class to be mocked as the single parameter without
additional interfaces.

BREAKING CHANGE: TestClass.for method no longer accepts generic types. the method
TestClass.testClassFor was removed as it is deprecated.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
